### PR TITLE
Fix func name

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -205,7 +205,7 @@ func createOverwriteDeleteSeq(t testing.TB, path string, data string, forbiddenF
 	return req
 }
 
-func randomDataAndId(t *testing.T) (string, string) {
+func generateRandomDataAndID(t *testing.T) (string, string) {
 	buf := make([]byte, 32)
 	_, err := io.ReadFull(rand.Reader, buf)
 	if err != nil {
@@ -258,7 +258,7 @@ func testResticHandler(t *testing.T, tests *TestSuite, server Server, pathsToCre
 
 // TestResticHandler runs tests on the restic handler code, default mode (everything allowed)
 func TestResticDefaultHandler(t *testing.T) {
-	data, fileID := randomDataAndId(t)
+	data, fileID := generateRandomDataAndID(t)
 
 	var tests = TestSuite{
 		{createOverwriteDeleteSeq(t, "/config", data, 0)},
@@ -278,7 +278,7 @@ func TestResticDefaultHandler(t *testing.T) {
 
 // TestResticHandler runs tests on the restic handler code, disabled blob verification
 func TestResticNoVerifyUploadHandler(t *testing.T) {
-	data, fileID := randomDataAndId(t)
+	data, fileID := generateRandomDataAndID(t)
 
 	var tests = TestSuite{
 		{createOverwriteDeleteSeq(t, "/config", data, 0)},
@@ -299,7 +299,7 @@ func TestResticNoVerifyUploadHandler(t *testing.T) {
 
 // TestResticHandler runs tests on the restic handler code, default mode (everything allowed)
 func TestResticAppendOnlyUploadHandler(t *testing.T) {
-	data, fileID := randomDataAndId(t)
+	data, fileID := generateRandomDataAndID(t)
 
 	var tests = TestSuite{
 		{createOverwriteDeleteSeq(t, "/config", data, DeleteForbidden)},
@@ -320,7 +320,7 @@ func TestResticAppendOnlyUploadHandler(t *testing.T) {
 
 // TestResticHandler runs tests on the restic handler code, default mode (everything allowed)
 func TestResticWriteOnlyUploadHandler(t *testing.T) {
-	data, fileID := randomDataAndId(t)
+	data, fileID := generateRandomDataAndID(t)
 
 	var tests = TestSuite{
 		{createOverwriteDeleteSeq(t, "/config", data, DeleteForbidden)},
@@ -341,7 +341,7 @@ func TestResticWriteOnlyUploadHandler(t *testing.T) {
 
 // TestResticHandler runs tests on the restic handler code, default mode (everything allowed)
 func TestResticPrivateRepoUploadHandler(t *testing.T) {
-	data, fileID := randomDataAndId(t)
+	data, fileID := generateRandomDataAndID(t)
 
 	var tests = TestSuite{
 		{createOverwriteDeleteSeq(t, "/parent1/sub1/config", "foobar", DeleteForbidden)},


### PR DESCRIPTION
Lint check at https://github.com/restic/rest-server/actions/runs/2397388054/jobs/3883463834 is failing on the func's name.

<!--
Thank you very much for contributing code or documentation to rest-server!

Please note that each PR should be preceded by an issue where the suggested
change can be discussed in general and without focus on specific code. That
way, work done in the PR will better match what's been agreed in the issue.

Please fill out the following questions to make it easier for us to review
your changes. You don't have to check all the checkboxes at once, instead
feel free to add more commits over time.
-->


What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, write "Closes #1234" such
that the issue is closed automatically when this PR is merged.
-->


Checklist
---------

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/rest-server/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/rest-server/commits/master)
- [x] I'm done, this Pull Request is ready for review
